### PR TITLE
Make recursion depth configurable for lockfile/package.json search

### DIFF
--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -15,6 +15,8 @@ import type {
 	SecurityFinding,
 } from './types';
 
+const DEFAULT_MAX_DEPTH = 10;
+
 // =============================================================================
 // SUSPICIOUS PATTERNS FOR ADVANCED DETECTION
 // =============================================================================
@@ -685,7 +687,11 @@ export function scanYarnLock(filePath: string): ScanResult[] {
  * @param scanNodeModules Whether to include node_modules directories in the scan. Defaults to false.
  * @returns Array of absolute lockfile paths.
  */
-export function findLockfiles(directory: string, scanNodeModules: boolean = false): string[] {
+export function findLockfiles(
+	directory: string,
+	scanNodeModules: boolean = false,
+	maxDepth: number = DEFAULT_MAX_DEPTH,
+): string[] {
 	const lockfiles: string[] = [];
 	const possibleFiles = [
 		'package-lock.json',
@@ -696,7 +702,7 @@ export function findLockfiles(directory: string, scanNodeModules: boolean = fals
 
 	// Search in root and subdirectories (for monorepos)
 	const searchDir = (dir: string, depth: number = 0) => {
-		if (depth > 5) return; // Limit depth to prevent excessive recursion
+		if (depth > maxDepth) return; // Limit depth to prevent excessive recursion
 
 		try {
 			const entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -724,17 +730,21 @@ export function findLockfiles(directory: string, scanNodeModules: boolean = fals
 }
 
 /**
- * Recursively locate package.json files up to depth 5 (monorepo friendly), skipping
+ * Recursively locate package.json files up to a configurable depth (monorepo friendly), skipping
  * node_modules and dot-prefixed directories.
  * @param directory Root search directory.
  * @param scanNodeModules Whether to include node_modules directories in the scan. Defaults to false.
  * @returns Array of package.json paths.
  */
-export function findPackageJsonFiles(directory: string, scanNodeModules: boolean = false): string[] {
+export function findPackageJsonFiles(
+	directory: string,
+	scanNodeModules: boolean = false,
+	maxDepth: number = DEFAULT_MAX_DEPTH,
+): string[] {
 	const packageFiles: string[] = [];
 
 	const searchDir = (dir: string, depth: number = 0) => {
-		if (depth > 5) return;
+		if (depth > maxDepth) return;
 
 		try {
 			const entries = fs.readdirSync(dir, { withFileTypes: true });


### PR DESCRIPTION
## Description

This PR replaces the hardcoded recursion limit (`depth > 5`) used in `findLockfiles()` and `findPackageJsonFiles()` with a configurable `maxDepth` parameter. The previous limit caused the detector to miss valid lockfiles and package.json files inside deeper directory structures commonly found in monorepos.

Example of a real-world layout that was skipped before:

```
repo/
  packages/
    web/
      apps/
        dashboard/
          frontend/
            client/
              package.json       <-- depth 7 (previously skipped)
              package-lock.json
```

Introducing `DEFAULT_MAX_DEPTH = 10` and making it configurable ensures full coverage in these environments while maintaining backward compatibility.

---

## Type of Change

* [ ] Package database update
* [x] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Other

---

## For Code Changes

### Changes Made

* Added `DEFAULT_MAX_DEPTH = 10`
* Added `maxDepth` parameter to both traversal functions
* Replaced all `depth > 5` checks with `depth > maxDepth`
* Updated docstrings to reflect configurable behavior
* No functional regressions - only expanded coverage

### Why This Is Good

* Prevents silent false negatives in deep monorepos
* Supports modern workspace setups (Nx, Turborepo, nested app folders)
* Safe and backward-compatible default
* Flexible for future CLI/option support

### Testing

* [x] Tested on shallow projects
* [x] Tested on a deep nested layout where original recursion failed
* [x] Build completed successfully (`npm run build`)

---

## Checklist

* [x] Read CONTRIBUTING.md
* [x] Code follows style guidelines
* [x] Ran `npm run build` and committed `dist/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File scanning functions now support a configurable depth limit parameter, enabling control over how deep directory traversal searches for dependency files. Default behavior is preserved when the parameter is not specified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->